### PR TITLE
PoC: KeyC and keyItemC shorter secondary constructors

### DIFF
--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/CommonKeys.kt
@@ -615,3 +615,9 @@ val SPACEBAR_FRENCH_TYPESPLIT_BOTTOM_KEY_ITEM =
                 KeyAction.ReplaceLastText(" ; ", trimCount = 3),
             ),
     )
+
+val DUMMY_KEY =
+    KeyC(
+        action = KeyAction.CommitText(""),
+        display = KeyDisplay.TextDisplay(""),
+    )

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLMessagEase.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.icons.outlined.ArrowDropUp
 import androidx.compose.material.icons.outlined.Copyright
 import androidx.compose.material.icons.outlined.KeyboardCapslock
 import com.dessalines.thumbkey.utils.ColorVariant
-import com.dessalines.thumbkey.utils.FontSizeVariant
 import com.dessalines.thumbkey.utils.KeyAction
 import com.dessalines.thumbkey.utils.KeyC
 import com.dessalines.thumbkey.utils.KeyDisplay
@@ -14,459 +13,74 @@ import com.dessalines.thumbkey.utils.KeyItemC
 import com.dessalines.thumbkey.utils.KeyboardC
 import com.dessalines.thumbkey.utils.KeyboardDefinition
 import com.dessalines.thumbkey.utils.KeyboardDefinitionModes
-import com.dessalines.thumbkey.utils.SwipeDirection
+
+val TAB_KEY =
+    KeyC(
+        display = KeyDisplay.TextDisplay("⇥"),
+        action = KeyAction.CommitText("\t"),
+        color = ColorVariant.MUTED,
+    )
 
 val KB_PL_MESSAGEASE_MAIN =
     KeyboardC(
         listOf(
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("a"),
-                            action = KeyAction.CommitText("a"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("-"),
-                                    action = KeyAction.CommitText("-"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("v"),
-                                    action = KeyAction.CommitText("v"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ą"),
-                                    action = KeyAction.CommitText("ą"),
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("$"),
-                                    action = KeyAction.CommitText("$"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
+                    DUMMY_KEY, KeyC('a'), KeyC('-'),
+                    KeyC('$'), KeyC('ą'), KeyC('v'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("n"),
-                            action = KeyAction.CommitText("n"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ń"),
-                                    action = KeyAction.CommitText("ń"),
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("!"),
-                                    action = KeyAction.CommitText("!"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\\"),
-                                    action = KeyAction.CommitText("\\"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("l"),
-                                    action = KeyAction.CommitText("l"),
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("/"),
-                                    action = KeyAction.CommitText("/"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("+"),
-                                    action = KeyAction.CommitText("+"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("`"),
-                                    action = KeyAction.CommitText("`"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("´"),
-                                    action = KeyAction.CommitText("´"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('`'), KeyC('ń'), KeyC('´'),
+                    KeyC('+'), KeyC('n'), KeyC('!'),
+                    KeyC('/'), KeyC('l'), KeyC('\\'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("i"),
-                            action = KeyAction.CommitText("i"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("€"),
-                                    action = KeyAction.CommitText("€"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("="),
-                                    action = KeyAction.CommitText("="),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("x"),
-                                    action = KeyAction.CommitText("x"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("?"),
-                                    action = KeyAction.CommitText("?"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ł"),
-                                    action = KeyAction.CommitText("ł"),
-                                ),
-                        ),
+                    KeyC('ł'), DUMMY_KEY, DUMMY_KEY,
+                    KeyC('?'), KeyC('i'), DUMMY_KEY,
+                    KeyC('x'), KeyC('='), KeyC('€'),
                 ),
                 EMOJI_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("w"),
-                            action = KeyAction.CommitText("w"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ó"),
-                                    action = KeyAction.CommitText("ó"),
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("%"),
-                                    action = KeyAction.CommitText("%"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("k"),
-                                    action = KeyAction.CommitText("k"),
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("_"),
-                                    action = KeyAction.CommitText("_"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ć"),
-                                    action = KeyAction.CommitText("ć"),
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("["),
-                                    action = KeyAction.CommitText("["),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("("),
-                                    action = KeyAction.CommitText("("),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("{"),
-                                    action = KeyAction.CommitText("{"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('{'), KeyC('ó'), KeyC('%'),
+                    KeyC('('), KeyC('w'), KeyC('k'),
+                    KeyC('['), KeyC('ć'), KeyC('_'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("o"),
-                            action = KeyAction.CommitText("o"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("u"),
-                                    action = KeyAction.CommitText("u"),
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("p"),
-                                    action = KeyAction.CommitText("p"),
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("b"),
-                                    action = KeyAction.CommitText("b"),
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("j"),
-                                    action = KeyAction.CommitText("j"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("d"),
-                                    action = KeyAction.CommitText("d"),
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("g"),
-                                    action = KeyAction.CommitText("g"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("c"),
-                                    action = KeyAction.CommitText("c"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("q"),
-                                    action = KeyAction.CommitText("q"),
-                                ),
-                        ),
+                    KeyC('q'), KeyC('u'), KeyC('p'),
+                    KeyC('c'), KeyC('o'), KeyC('b'),
+                    KeyC('g'), KeyC('d'), KeyC('j'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("r"),
-                            action = KeyAction.CommitText("r"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
-                                    action = KeyAction.ToggleShiftMode(true),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("}"),
-                                    action = KeyAction.CommitText("}"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(")"),
-                                    action = KeyAction.CommitText(")"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("]"),
-                                    action = KeyAction.CommitText("]"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("@"),
-                                    action = KeyAction.CommitText("@"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("m"),
-                                    action = KeyAction.CommitText("m"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("|"),
-                                    action = KeyAction.CommitText("|"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('|'),
+                    KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropUp),
+                        action = KeyAction.ToggleShiftMode(true),
+                        color = ColorVariant.MUTED,
+                    ),
+                    KeyC('}'),
+                    KeyC('m'), KeyC('r'), KeyC(')'),
+                    KeyC('@'), DUMMY_KEY, KeyC(']'),
                 ),
                 NUMERIC_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("z"),
-                            action = KeyAction.CommitText("z"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("y"),
-                                    action = KeyAction.CommitText("y"),
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ź"),
-                                    action = KeyAction.CommitText("ź"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ę"),
-                                    action = KeyAction.CommitText("ę"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("<"),
-                                    action = KeyAction.CommitText("<"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("~"),
-                                    action = KeyAction.CommitText("~"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("⇥"),
-                                    action = KeyAction.CommitText("\t"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('~'), DUMMY_KEY, KeyC('y'),
+                    KeyC('<'), KeyC('z'), KeyC('ź'),
+                    DUMMY_KEY, KeyC('ę'), TAB_KEY,
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("e"),
-                            action = KeyAction.CommitText("e"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("h"),
-                                    action = KeyAction.CommitText("h"),
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\'"),
-                                    action = KeyAction.CommitText("\'"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("t"),
-                                    action = KeyAction.CommitText("t"),
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(":"),
-                                    action = KeyAction.CommitText(":"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("."),
-                                    action = KeyAction.CommitText("."),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(","),
-                                    action = KeyAction.CommitText(","),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ż"),
-                                    action = KeyAction.CommitText("ż"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\""),
-                                    action = KeyAction.CommitText("\""),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('\"'), KeyC('h'), KeyC('\''),
+                    KeyC('ż'), KeyC('e'), KeyC('t'),
+                    KeyC(','), KeyC('.'), KeyC(':'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("s"),
-                            action = KeyAction.CommitText("s"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("&"),
-                                    action = KeyAction.CommitText("&"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("°"),
-                                    action = KeyAction.CommitText("°"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(">"),
-                                    action = KeyAction.CommitText(">"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(";"),
-                                    action = KeyAction.CommitText(";"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("ś"),
-                                    action = KeyAction.CommitText("ś"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("f"),
-                                    action = KeyAction.CommitText("f"),
-                                ),
-                        ),
+                    KeyC('f'), KeyC('&'), KeyC('°'),
+                    KeyC('ś'), KeyC('s'), KeyC('>'),
+                    KeyC(';'), DUMMY_KEY, DUMMY_KEY,
                 ),
                 BACKSPACE_KEY_ITEM,
             ),
@@ -482,457 +96,68 @@ val KB_PL_MESSAGEASE_SHIFTED =
         listOf(
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("A"),
-                            action = KeyAction.CommitText("A"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("-"),
-                                    action = KeyAction.CommitText("-"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("V"),
-                                    action = KeyAction.CommitText("V"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ą"),
-                                    action = KeyAction.CommitText("Ą"),
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("$"),
-                                    action = KeyAction.CommitText("$"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
+                    DUMMY_KEY, KeyC('A'), KeyC('-'),
+                    KeyC('$'), KeyC('Ą'), KeyC('V'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("N"),
-                            action = KeyAction.CommitText("N"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ń"),
-                                    action = KeyAction.CommitText("Ń"),
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("!"),
-                                    action = KeyAction.CommitText("!"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\\"),
-                                    action = KeyAction.CommitText("\\"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("L"),
-                                    action = KeyAction.CommitText("L"),
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("/"),
-                                    action = KeyAction.CommitText("/"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("+"),
-                                    action = KeyAction.CommitText("+"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("`"),
-                                    action = KeyAction.CommitText("`"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("´"),
-                                    action = KeyAction.CommitText("´"),
-                                ),
-                        ),
+                    KeyC('`'), KeyC('Ń'), KeyC('´'),
+                    KeyC('+'), KeyC('N'), KeyC('!'),
+                    KeyC('/'), KeyC('L'), KeyC('\\'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("I"),
-                            action = KeyAction.CommitText("I"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("€"),
-                                    action = KeyAction.CommitText("€"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("="),
-                                    action = KeyAction.CommitText("="),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("X"),
-                                    action = KeyAction.CommitText("X"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("?"),
-                                    action = KeyAction.CommitText("?"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ł"),
-                                    action = KeyAction.CommitText("Ł"),
-                                ),
-                        ),
+                    KeyC('Ł'), DUMMY_KEY, DUMMY_KEY,
+                    KeyC('?'), KeyC('I'), DUMMY_KEY,
+                    KeyC('X'), KeyC('='), KeyC('€'),
                 ),
                 EMOJI_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("W"),
-                            action = KeyAction.CommitText("W"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ó"),
-                                    action = KeyAction.CommitText("Ó"),
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("%"),
-                                    action = KeyAction.CommitText("%"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("K"),
-                                    action = KeyAction.CommitText("K"),
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("_"),
-                                    action = KeyAction.CommitText("_"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ć"),
-                                    action = KeyAction.CommitText("Ć"),
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("["),
-                                    action = KeyAction.CommitText("["),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("("),
-                                    action = KeyAction.CommitText("("),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("{"),
-                                    action = KeyAction.CommitText("{"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('{'), KeyC('Ó'), KeyC('%'),
+                    KeyC('('), KeyC('W'), KeyC('K'),
+                    KeyC('['), KeyC('Ć'), KeyC('_'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("O"),
-                            action = KeyAction.CommitText("O"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("U"),
-                                    action = KeyAction.CommitText("U"),
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("P"),
-                                    action = KeyAction.CommitText("P"),
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("B"),
-                                    action = KeyAction.CommitText("B"),
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("J"),
-                                    action = KeyAction.CommitText("J"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("D"),
-                                    action = KeyAction.CommitText("D"),
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("G"),
-                                    action = KeyAction.CommitText("G"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("C"),
-                                    action = KeyAction.CommitText("C"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Q"),
-                                    action = KeyAction.CommitText("Q"),
-                                ),
-                        ),
+                    KeyC('Q'), KeyC('U'), KeyC('P'),
+                    KeyC('C'), KeyC('O'), KeyC('B'),
+                    KeyC('G'), KeyC('D'), KeyC('J'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("R"),
-                            action = KeyAction.CommitText("R"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
-                                    action = KeyAction.ToggleShiftMode(false),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
-                                    capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
-                                    action = KeyAction.ToggleCapsLock,
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("}"),
-                                    action = KeyAction.CommitText("}"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(")"),
-                                    action = KeyAction.CommitText(")"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("]"),
-                                    action = KeyAction.CommitText("]"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("@"),
-                                    action = KeyAction.CommitText("@"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("M"),
-                                    action = KeyAction.CommitText("M"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("|"),
-                                    action = KeyAction.CommitText("|"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('|'),
+                    KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.KeyboardCapslock),
+                        capsModeDisplay = KeyDisplay.IconDisplay(Icons.Outlined.Copyright),
+                        action = KeyAction.ToggleCapsLock,
+                        color = ColorVariant.MUTED,
+                    ),
+                    KeyC('}'),
+                    KeyC('M'), KeyC('R'), KeyC(')'),
+                    KeyC('@'),
+                    KeyC(
+                        display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
+                        action = KeyAction.ToggleShiftMode(false),
+                        color = ColorVariant.MUTED,
+                    ),
+                    KeyC(']'),
                 ),
                 NUMERIC_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("Z"),
-                            action = KeyAction.CommitText("Z"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Y"),
-                                    action = KeyAction.CommitText("Y"),
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ź"),
-                                    action = KeyAction.CommitText("Ź"),
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ę"),
-                                    action = KeyAction.CommitText("Ę"),
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("<"),
-                                    action = KeyAction.CommitText("<"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("~"),
-                                    action = KeyAction.CommitText("~"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("⇥"),
-                                    action = KeyAction.CommitText("\t"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('~'), DUMMY_KEY, KeyC('Y'),
+                    KeyC('<'), KeyC('Z'), KeyC('Ź'),
+                    DUMMY_KEY, KeyC('Ę'), TAB_KEY,
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("E"),
-                            action = KeyAction.CommitText("E"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("H"),
-                                    action = KeyAction.CommitText("H"),
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\'"),
-                                    action = KeyAction.CommitText("\'"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("T"),
-                                    action = KeyAction.CommitText("T"),
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(":"),
-                                    action = KeyAction.CommitText(":"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("."),
-                                    action = KeyAction.CommitText("."),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(","),
-                                    action = KeyAction.CommitText(","),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ż"),
-                                    action = KeyAction.CommitText("Ż"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\""),
-                                    action = KeyAction.CommitText("\""),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('\"'), KeyC('H'), KeyC('\''),
+                    KeyC('Ż'), KeyC('E'), KeyC('T'),
+                    KeyC(','), KeyC('.'), KeyC(':'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("S"),
-                            action = KeyAction.CommitText("S"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("&"),
-                                    action = KeyAction.CommitText("&"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("°"),
-                                    action = KeyAction.CommitText("°"),
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(">"),
-                                    action = KeyAction.CommitText(">"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(";"),
-                                    action = KeyAction.CommitText(";"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("Ś"),
-                                    action = KeyAction.CommitText("Ś"),
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("F"),
-                                    action = KeyAction.CommitText("F"),
-                                ),
-                        ),
+                    KeyC('F'), KeyC('&'), KeyC('°'),
+                    KeyC('Ś'), KeyC('S'), KeyC('>'),
+                    KeyC(';'), DUMMY_KEY, DUMMY_KEY,
                 ),
                 BACKSPACE_KEY_ITEM,
             ),
@@ -948,341 +173,62 @@ val KB_PL_MESSAGEASE_NUMERIC =
         listOf(
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("1"),
-                            action = KeyAction.CommitText("1"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("-"),
-                                    action = KeyAction.CommitText("-"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("$"),
-                                    action = KeyAction.CommitText("$"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
+                    DUMMY_KEY, KeyC('1'), KeyC('-'),
+                    KeyC('$'), DUMMY_KEY, DUMMY_KEY,
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("2"),
-                            action = KeyAction.CommitText("2"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("!"),
-                                    action = KeyAction.CommitText("!"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\\"),
-                                    action = KeyAction.CommitText("\\"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("/"),
-                                    action = KeyAction.CommitText("/"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("+"),
-                                    action = KeyAction.CommitText("+"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("^"),
-                                    action = KeyAction.CommitText("^"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("`"),
-                                    action = KeyAction.CommitText("`"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("´"),
-                                    action = KeyAction.CommitText("´"),
-                                ),
-                        ),
+                    KeyC('`'), KeyC('^'), KeyC('´'),
+                    KeyC('+'), KeyC('2'), KeyC('!'),
+                    KeyC('/'), DUMMY_KEY, KeyC('\\'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("3"),
-                            action = KeyAction.CommitText("3"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("€"),
-                                    action = KeyAction.CommitText("€"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("="),
-                                    action = KeyAction.CommitText("="),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("?"),
-                                    action = KeyAction.CommitText("?"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
+                    KeyC('?'), KeyC('3'), DUMMY_KEY,
+                    DUMMY_KEY, KeyC('='), KeyC('€'),
                 ),
                 EMOJI_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("4"),
-                            action = KeyAction.CommitText("4"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("%"),
-                                    action = KeyAction.CommitText("%"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("_"),
-                                    action = KeyAction.CommitText("_"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("["),
-                                    action = KeyAction.CommitText("["),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("("),
-                                    action = KeyAction.CommitText("("),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("{"),
-                                    action = KeyAction.CommitText("{"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('{'), DUMMY_KEY, KeyC('%'),
+                    KeyC('('), KeyC('4'), DUMMY_KEY,
+                    KeyC('['), DUMMY_KEY, KeyC('_'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("5"),
-                            action = KeyAction.CommitText("5"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
+                    DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
+                    DUMMY_KEY, KeyC('5'), DUMMY_KEY,
+                    DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("6"),
-                            action = KeyAction.CommitText("6"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("}"),
-                                    action = KeyAction.CommitText("}"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(")"),
-                                    action = KeyAction.CommitText(")"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("]"),
-                                    action = KeyAction.CommitText("]"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("@"),
-                                    action = KeyAction.CommitText("@"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("|"),
-                                    action = KeyAction.CommitText("|"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('|'), DUMMY_KEY, KeyC('}'),
+                    DUMMY_KEY, KeyC('6'), KeyC(')'),
+                    KeyC('@'), DUMMY_KEY, KeyC(']'),
                 ),
                 ABC_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("7"),
-                            action = KeyAction.CommitText("7"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("*"),
-                                    action = KeyAction.CommitText("*"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("<"),
-                                    action = KeyAction.CommitText("<"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("~"),
-                                    action = KeyAction.CommitText("~"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("⇥"),
-                                    action = KeyAction.CommitText("\t"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('~'), DUMMY_KEY, DUMMY_KEY,
+                    KeyC('<'), KeyC('7'), KeyC('*'),
+                    DUMMY_KEY, DUMMY_KEY, TAB_KEY,
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("8"),
-                            action = KeyAction.CommitText("8"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\'"),
-                                    action = KeyAction.CommitText("\'"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(":"),
-                                    action = KeyAction.CommitText(":"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("."),
-                                    action = KeyAction.CommitText("."),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(","),
-                                    action = KeyAction.CommitText(","),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("\""),
-                                    action = KeyAction.CommitText("\""),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    KeyC('\"'), DUMMY_KEY, KeyC('\''),
+                    DUMMY_KEY, KeyC('8'), DUMMY_KEY,
+                    KeyC(','), KeyC('.'), KeyC(':'),
                 ),
                 KeyItemC(
-                    center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("9"),
-                            action = KeyAction.CommitText("9"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
-                    swipes =
-                        mapOf(
-                            SwipeDirection.TOP to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("&"),
-                                    action = KeyAction.CommitText("&"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.TOP_RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("°"),
-                                    action = KeyAction.CommitText("°"),
-                                ),
-                            SwipeDirection.RIGHT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(">"),
-                                    action = KeyAction.CommitText(">"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.BOTTOM_LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay(";"),
-                                    action = KeyAction.CommitText(";"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                            SwipeDirection.LEFT to
-                                KeyC(
-                                    display = KeyDisplay.TextDisplay("#"),
-                                    action = KeyAction.CommitText("#"),
-                                    color = ColorVariant.MUTED,
-                                ),
-                        ),
+                    DUMMY_KEY, KeyC('&'), KeyC('°'),
+                    KeyC('#'), KeyC('9'), KeyC('>'),
+                    KeyC(';'), DUMMY_KEY, DUMMY_KEY,
                 ),
                 BACKSPACE_KEY_ITEM,
             ),
             listOf(
                 KeyItemC(
                     center =
-                        KeyC(
-                            display = KeyDisplay.TextDisplay("0"),
-                            action = KeyAction.CommitText("0"),
-                            size = FontSizeVariant.LARGE,
-                            color = ColorVariant.PRIMARY,
-                        ),
+                        KeyC('0'),
                     widthMultiplier = 2,
                 ),
                 SPACEBAR_SKINNY_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/keyboards/PLMessagEase.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/keyboards/PLMessagEase.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.outlined.ArrowDropUp
 import androidx.compose.material.icons.outlined.Copyright
 import androidx.compose.material.icons.outlined.KeyboardCapslock
 import com.dessalines.thumbkey.utils.ColorVariant
+import com.dessalines.thumbkey.utils.FontSizeVariant
 import com.dessalines.thumbkey.utils.KeyAction
 import com.dessalines.thumbkey.utils.KeyC
 import com.dessalines.thumbkey.utils.KeyDisplay
@@ -27,17 +28,17 @@ val KB_PL_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
-                    DUMMY_KEY, KeyC('a'), KeyC('-'),
+                    DUMMY_KEY, KeyC('a', FontSizeVariant.LARGE), KeyC('-'),
                     KeyC('$'), KeyC('ą'), KeyC('v'),
                 ),
                 KeyItemC(
                     KeyC('`'), KeyC('ń'), KeyC('´'),
-                    KeyC('+'), KeyC('n'), KeyC('!'),
+                    KeyC('+'), KeyC('n', FontSizeVariant.LARGE), KeyC('!'),
                     KeyC('/'), KeyC('l'), KeyC('\\'),
                 ),
                 KeyItemC(
                     KeyC('ł'), DUMMY_KEY, DUMMY_KEY,
-                    KeyC('?'), KeyC('i'), DUMMY_KEY,
+                    KeyC('?'), KeyC('i', FontSizeVariant.LARGE), DUMMY_KEY,
                     KeyC('x'), KeyC('='), KeyC('€'),
                 ),
                 EMOJI_KEY_ITEM,
@@ -45,12 +46,12 @@ val KB_PL_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     KeyC('{'), KeyC('ó'), KeyC('%'),
-                    KeyC('('), KeyC('w'), KeyC('k'),
+                    KeyC('('), KeyC('w', FontSizeVariant.LARGE), KeyC('k'),
                     KeyC('['), KeyC('ć'), KeyC('_'),
                 ),
                 KeyItemC(
                     KeyC('q'), KeyC('u'), KeyC('p'),
-                    KeyC('c'), KeyC('o'), KeyC('b'),
+                    KeyC('c'), KeyC('o', FontSizeVariant.LARGE), KeyC('b'),
                     KeyC('g'), KeyC('d'), KeyC('j'),
                 ),
                 KeyItemC(
@@ -61,7 +62,7 @@ val KB_PL_MESSAGEASE_MAIN =
                         color = ColorVariant.MUTED,
                     ),
                     KeyC('}'),
-                    KeyC('m'), KeyC('r'), KeyC(')'),
+                    KeyC('m'), KeyC('r', FontSizeVariant.LARGE), KeyC(')'),
                     KeyC('@'), DUMMY_KEY, KeyC(']'),
                 ),
                 NUMERIC_KEY_ITEM,
@@ -69,17 +70,17 @@ val KB_PL_MESSAGEASE_MAIN =
             listOf(
                 KeyItemC(
                     KeyC('~'), DUMMY_KEY, KeyC('y'),
-                    KeyC('<'), KeyC('z'), KeyC('ź'),
+                    KeyC('<'), KeyC('z', FontSizeVariant.LARGE), KeyC('ź'),
                     DUMMY_KEY, KeyC('ę'), TAB_KEY,
                 ),
                 KeyItemC(
                     KeyC('\"'), KeyC('h'), KeyC('\''),
-                    KeyC('ż'), KeyC('e'), KeyC('t'),
+                    KeyC('ż'), KeyC('e', FontSizeVariant.LARGE), KeyC('t'),
                     KeyC(','), KeyC('.'), KeyC(':'),
                 ),
                 KeyItemC(
                     KeyC('f'), KeyC('&'), KeyC('°'),
-                    KeyC('ś'), KeyC('s'), KeyC('>'),
+                    KeyC('ś'), KeyC('s', FontSizeVariant.LARGE), KeyC('>'),
                     KeyC(';'), DUMMY_KEY, DUMMY_KEY,
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -97,17 +98,17 @@ val KB_PL_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
-                    DUMMY_KEY, KeyC('A'), KeyC('-'),
+                    DUMMY_KEY, KeyC('A', FontSizeVariant.LARGE), KeyC('-'),
                     KeyC('$'), KeyC('Ą'), KeyC('V'),
                 ),
                 KeyItemC(
                     KeyC('`'), KeyC('Ń'), KeyC('´'),
-                    KeyC('+'), KeyC('N'), KeyC('!'),
+                    KeyC('+'), KeyC('N', FontSizeVariant.LARGE), KeyC('!'),
                     KeyC('/'), KeyC('L'), KeyC('\\'),
                 ),
                 KeyItemC(
                     KeyC('Ł'), DUMMY_KEY, DUMMY_KEY,
-                    KeyC('?'), KeyC('I'), DUMMY_KEY,
+                    KeyC('?'), KeyC('I', FontSizeVariant.LARGE), DUMMY_KEY,
                     KeyC('X'), KeyC('='), KeyC('€'),
                 ),
                 EMOJI_KEY_ITEM,
@@ -115,12 +116,12 @@ val KB_PL_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     KeyC('{'), KeyC('Ó'), KeyC('%'),
-                    KeyC('('), KeyC('W'), KeyC('K'),
+                    KeyC('('), KeyC('W', FontSizeVariant.LARGE), KeyC('K'),
                     KeyC('['), KeyC('Ć'), KeyC('_'),
                 ),
                 KeyItemC(
                     KeyC('Q'), KeyC('U'), KeyC('P'),
-                    KeyC('C'), KeyC('O'), KeyC('B'),
+                    KeyC('C'), KeyC('O', FontSizeVariant.LARGE), KeyC('B'),
                     KeyC('G'), KeyC('D'), KeyC('J'),
                 ),
                 KeyItemC(
@@ -132,7 +133,7 @@ val KB_PL_MESSAGEASE_SHIFTED =
                         color = ColorVariant.MUTED,
                     ),
                     KeyC('}'),
-                    KeyC('M'), KeyC('R'), KeyC(')'),
+                    KeyC('M'), KeyC('R', FontSizeVariant.LARGE), KeyC(')'),
                     KeyC('@'),
                     KeyC(
                         display = KeyDisplay.IconDisplay(Icons.Outlined.ArrowDropDown),
@@ -146,17 +147,17 @@ val KB_PL_MESSAGEASE_SHIFTED =
             listOf(
                 KeyItemC(
                     KeyC('~'), DUMMY_KEY, KeyC('Y'),
-                    KeyC('<'), KeyC('Z'), KeyC('Ź'),
+                    KeyC('<'), KeyC('Z', FontSizeVariant.LARGE), KeyC('Ź'),
                     DUMMY_KEY, KeyC('Ę'), TAB_KEY,
                 ),
                 KeyItemC(
                     KeyC('\"'), KeyC('H'), KeyC('\''),
-                    KeyC('Ż'), KeyC('E'), KeyC('T'),
+                    KeyC('Ż'), KeyC('E', FontSizeVariant.LARGE), KeyC('T'),
                     KeyC(','), KeyC('.'), KeyC(':'),
                 ),
                 KeyItemC(
                     KeyC('F'), KeyC('&'), KeyC('°'),
-                    KeyC('Ś'), KeyC('S'), KeyC('>'),
+                    KeyC('Ś'), KeyC('S', FontSizeVariant.LARGE), KeyC('>'),
                     KeyC(';'), DUMMY_KEY, DUMMY_KEY,
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -174,17 +175,17 @@ val KB_PL_MESSAGEASE_NUMERIC =
             listOf(
                 KeyItemC(
                     DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
-                    DUMMY_KEY, KeyC('1'), KeyC('-'),
+                    DUMMY_KEY, KeyC('1', FontSizeVariant.LARGE), KeyC('-'),
                     KeyC('$'), DUMMY_KEY, DUMMY_KEY,
                 ),
                 KeyItemC(
                     KeyC('`'), KeyC('^'), KeyC('´'),
-                    KeyC('+'), KeyC('2'), KeyC('!'),
+                    KeyC('+'), KeyC('2', FontSizeVariant.LARGE), KeyC('!'),
                     KeyC('/'), DUMMY_KEY, KeyC('\\'),
                 ),
                 KeyItemC(
                     DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
-                    KeyC('?'), KeyC('3'), DUMMY_KEY,
+                    KeyC('?'), KeyC('3', FontSizeVariant.LARGE), DUMMY_KEY,
                     DUMMY_KEY, KeyC('='), KeyC('€'),
                 ),
                 EMOJI_KEY_ITEM,
@@ -192,17 +193,17 @@ val KB_PL_MESSAGEASE_NUMERIC =
             listOf(
                 KeyItemC(
                     KeyC('{'), DUMMY_KEY, KeyC('%'),
-                    KeyC('('), KeyC('4'), DUMMY_KEY,
+                    KeyC('('), KeyC('4', FontSizeVariant.LARGE), DUMMY_KEY,
                     KeyC('['), DUMMY_KEY, KeyC('_'),
                 ),
                 KeyItemC(
                     DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
-                    DUMMY_KEY, KeyC('5'), DUMMY_KEY,
+                    DUMMY_KEY, KeyC('5', FontSizeVariant.LARGE), DUMMY_KEY,
                     DUMMY_KEY, DUMMY_KEY, DUMMY_KEY,
                 ),
                 KeyItemC(
                     KeyC('|'), DUMMY_KEY, KeyC('}'),
-                    DUMMY_KEY, KeyC('6'), KeyC(')'),
+                    DUMMY_KEY, KeyC('6', FontSizeVariant.LARGE), KeyC(')'),
                     KeyC('@'), DUMMY_KEY, KeyC(']'),
                 ),
                 ABC_KEY_ITEM,
@@ -210,17 +211,17 @@ val KB_PL_MESSAGEASE_NUMERIC =
             listOf(
                 KeyItemC(
                     KeyC('~'), DUMMY_KEY, DUMMY_KEY,
-                    KeyC('<'), KeyC('7'), KeyC('*'),
+                    KeyC('<'), KeyC('7', FontSizeVariant.LARGE), KeyC('*'),
                     DUMMY_KEY, DUMMY_KEY, TAB_KEY,
                 ),
                 KeyItemC(
                     KeyC('\"'), DUMMY_KEY, KeyC('\''),
-                    DUMMY_KEY, KeyC('8'), DUMMY_KEY,
+                    DUMMY_KEY, KeyC('8', FontSizeVariant.LARGE), DUMMY_KEY,
                     KeyC(','), KeyC('.'), KeyC(':'),
                 ),
                 KeyItemC(
                     DUMMY_KEY, KeyC('&'), KeyC('°'),
-                    KeyC('#'), KeyC('9'), KeyC('>'),
+                    KeyC('#'), KeyC('9', FontSizeVariant.LARGE), KeyC('>'),
                     KeyC(';'), DUMMY_KEY, DUMMY_KEY,
                 ),
                 BACKSPACE_KEY_ITEM,
@@ -228,7 +229,7 @@ val KB_PL_MESSAGEASE_NUMERIC =
             listOf(
                 KeyItemC(
                     center =
-                        KeyC('0'),
+                        KeyC('0', FontSizeVariant.LARGE),
                     widthMultiplier = 2,
                 ),
                 SPACEBAR_SKINNY_KEY_ITEM,

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -4,6 +4,7 @@ import android.view.KeyEvent
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.dessalines.thumbkey.R
+import com.dessalines.thumbkey.keyboards.DUMMY_KEY
 
 data class KeyboardDefinitionModes(
     val main: KeyboardC,
@@ -62,16 +63,16 @@ data class KeyItemC(
     ) : this(
         center = center,
         swipes =
-            mapOf(
-                SwipeDirection.TOP_LEFT to topLeft,
-                SwipeDirection.TOP to top,
-                SwipeDirection.TOP_RIGHT to topRight,
-                SwipeDirection.LEFT to left,
-                SwipeDirection.RIGHT to right,
-                SwipeDirection.BOTTOM_LEFT to bottomLeft,
-                SwipeDirection.BOTTOM to bottom,
-                SwipeDirection.BOTTOM_RIGHT to bottomRight,
-            ),
+            listOfNotNull(
+                (SwipeDirection.TOP_LEFT to topLeft).takeIf { topLeft != DUMMY_KEY },
+                (SwipeDirection.TOP to top).takeIf { top != DUMMY_KEY },
+                (SwipeDirection.TOP_RIGHT to topRight).takeIf { topRight != DUMMY_KEY },
+                (SwipeDirection.LEFT to left).takeIf { left != DUMMY_KEY },
+                (SwipeDirection.RIGHT to right).takeIf { right != DUMMY_KEY },
+                (SwipeDirection.BOTTOM_LEFT to bottomLeft).takeIf { bottomLeft != DUMMY_KEY },
+                (SwipeDirection.BOTTOM to bottom).takeIf { bottom != DUMMY_KEY },
+                (SwipeDirection.BOTTOM_RIGHT to bottomRight).takeIf { bottomRight != DUMMY_KEY },
+            ).toMap(),
     )
 }
 

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -83,10 +83,11 @@ data class KeyC(
     val color: ColorVariant = ColorVariant.SECONDARY,
     val size: FontSizeVariant = FontSizeVariant.SMALL,
 ) {
-    constructor(character: Char) : this(
+    constructor(character: Char, size: FontSizeVariant = FontSizeVariant.SMALL) : this(
         display = KeyDisplay.TextDisplay(character.toString()),
         action = KeyAction.CommitText(character.toString()),
         color = if (character.isLetterOrDigit()) ColorVariant.SECONDARY else ColorVariant.MUTED,
+        size = size,
     )
 }
 

--- a/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
+++ b/app/src/main/java/com/dessalines/thumbkey/utils/Types.kt
@@ -48,7 +48,32 @@ data class KeyItemC(
     val swipeType: SwipeNWay = SwipeNWay.EIGHT_WAY,
     val slideType: SlideType = SlideType.NONE,
     val longPress: KeyAction? = null,
-)
+) {
+    constructor(
+        topLeft: KeyC,
+        top: KeyC,
+        topRight: KeyC,
+        left: KeyC,
+        center: KeyC,
+        right: KeyC,
+        bottomLeft: KeyC,
+        bottom: KeyC,
+        bottomRight: KeyC,
+    ) : this(
+        center = center,
+        swipes =
+            mapOf(
+                SwipeDirection.TOP_LEFT to topLeft,
+                SwipeDirection.TOP to top,
+                SwipeDirection.TOP_RIGHT to topRight,
+                SwipeDirection.LEFT to left,
+                SwipeDirection.RIGHT to right,
+                SwipeDirection.BOTTOM_LEFT to bottomLeft,
+                SwipeDirection.BOTTOM to bottom,
+                SwipeDirection.BOTTOM_RIGHT to bottomRight,
+            ),
+    )
+}
 
 data class KeyC(
     val display: KeyDisplay?,
@@ -56,7 +81,13 @@ data class KeyC(
     val action: KeyAction,
     val color: ColorVariant = ColorVariant.SECONDARY,
     val size: FontSizeVariant = FontSizeVariant.SMALL,
-)
+) {
+    constructor(character: Char) : this(
+        display = KeyDisplay.TextDisplay(character.toString()),
+        action = KeyAction.CommitText(character.toString()),
+        color = if (character.isLetterOrDigit()) ColorVariant.SECONDARY else ColorVariant.MUTED,
+    )
+}
 
 sealed class KeyDisplay {
     class TextDisplay(val text: String) : KeyDisplay()


### PR DESCRIPTION
Maybe it should use helper functions instead of secondary constructors?

Is dummy keys filtering breaking compile-time checking?